### PR TITLE
fix: add setimmediate polyfill to index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ import './src/common/config/analytics/CrashAnalytics'
 import './src/common/services/layoutAnimation'
 import 'react-native-gesture-handler'
 import 'expo-asset'
+import 'setimmediate'
 
 import { createElement } from 'react'
 import { createRoot } from 'react-dom/client'


### PR DESCRIPTION
I encountered the below error on certain pages / menus when running the app with `yarn web:webkit` in chrome.  For example, when trying to add a new account (Accounts > "+ Add Account").

<img width="590" height="490" alt="image" src="https://github.com/user-attachments/assets/d9c6e144-1378-4f5a-8cc5-ececc52dbd41" />

```
Uncaught ReferenceError: setImmediate is not defined
    at Handler.componentDidMount (createHandler.tsx:213:1)
    at commitLayoutEffectOnFiber (react-dom.development.js:23209:1)
    at commitLayoutMountEffects_complete (react-dom.development.js:24578:1)
    at commitLayoutEffects_begin (react-dom.development.js:24564:1)
    at commitLayoutEffects (react-dom.development.js:24502:1)
    at commitRootImpl (react-dom.development.js:26779:1)
    at commitRoot (react-dom.development.js:26638:1)
    at performSyncWorkOnRoot (react-dom.development.js:26073:1)
    at flushSyncCallbacks (react-dom.development.js:12009:1)
    at react-dom.development.js:25607:1Caused by: React ErrorBoundary ReferenceError: setImmediate is not defined
...
   at GestureHandlerRootView
    at GestureHandler (GestureHandler.tsx:7:1)
    at ThemeProvider (themeContext.tsx:31:1)
    at WalletStateControllerProvider (walletStateControllerContext.tsx:13:1)
    at StorageControllerStateProvider (storageControllerStateContext.tsx:10:1)
    at MainControllerStateProvider (mainControllerStateContext.tsx:11:1)
    at BackgroundServiceProvider (backgroundServiceContext.tsx:98:1)
    at ErrorBoundary (errorboundary.tsx:101:1)
    at ToastProvider (toastContext.tsx:51:1)
    at div
    at index.js:35:1
    at NativeSafeAreaProvider (NativeSafeAreaProvider.web.tsx:27:1)
    at SafeAreaProvider (SafeAreaContext.tsx:40:1)
    at PortalProviderComponent (PortalProvider.tsx:12:1)
    at Router (components.tsx:300:1)
    at HashRouter (index.tsx:326:1)
    at AppInit (AppInit.web.tsx:56:1)
    at App
```

Ultimately just adding this shim fixed things.  Oddly, adding the `setimmediate` import into `shim.js` didn't work and I instead had to add it to `index.js`.  I think this is due to import ordering, but honestly not sure.