### PR TITLE
fix: validate when no labels

### DIFF
--- a/src/web/modules/PPv1/utils/sdk.ts
+++ b/src/web/modules/PPv1/utils/sdk.ts
@@ -108,6 +108,10 @@ export const processDeposits = async (
   // Extract labels from pool accounts to fetch only relevant deposits
   const labels = loadedPoolAccounts.map((account) => account.label.toString())
 
+  if (!labels.length) {
+    return []
+  }
+
   // Fetch deposit data from ASP for specific labels
   const depositData = await aspClient.fetchDepositsByLabel(aspUrl, chainId, scope, labels)
 


### PR DESCRIPTION
- When a new account without deposits is added, it will not have labels, so we should not attempt to retrieve deposits.