### PR TITLE
fix: hex colors opacity

### DIFF
--- a/src/web/modules/networks/components/AllNetworksOption/AllNetworksOption.tsx
+++ b/src/web/modules/networks/components/AllNetworksOption/AllNetworksOption.tsx
@@ -31,7 +31,7 @@ const AllNetworksOption = ({ onPress }: { onPress: (chainId: bigint | null) => v
         from:
           themeType === THEME_TYPES.DARK
             ? `${String(theme.primaryLight)}00`
-            : `${String(theme.secondaryBorder)}00`,
+            : `${String(theme.secondaryBorder)}`,
         to: themeType === THEME_TYPES.DARK ? theme.primaryLight80 : theme.secondaryBorder
       }
     ],

--- a/src/web/modules/networks/components/Networks/Network/Network.tsx
+++ b/src/web/modules/networks/components/Networks/Network/Network.tsx
@@ -40,7 +40,7 @@ const Network: FC<Props> = ({ chainId, openBlockExplorer, openSettingsBottomShee
         from:
           themeType === THEME_TYPES.DARK
             ? `${String(theme.primaryLight)}00`
-            : `${String(theme.secondaryBorder)}00`,
+            : `${String(theme.secondaryBorder)}`,
         to: themeType === THEME_TYPES.DARK ? theme.primaryLight80 : theme.secondaryBorder
       }
     ],


### PR DESCRIPTION
Removed opacity from colors that already had it in theme (so the problem was trying to use ```useMultiHover``` hook with broke hex colors)