### PR TITLE
fix: disable unwanted banners

### DIFF
--- a/src/common/modules/dashboard/hooks/useBanners/useBanners.ts
+++ b/src/common/modules/dashboard/hooks/useBanners/useBanners.ts
@@ -75,5 +75,5 @@ export default function useBanners(): [BannerInterface[], BannerInterface[]] {
     firstCashbackBanner
   ])
 
-  return [controllerBanners, marketingBanners]
+  return [controllerBanners, filterDisabledBanners(marketingBanners)]
 }

--- a/src/web/config/disabledBanners.ts
+++ b/src/web/config/disabledBanners.ts
@@ -4,7 +4,8 @@ import { Banner } from '@ambire-common/interfaces/banner'
  * List of banner IDs that should be disabled/hidden from the UI for the current iteration
  */
 export const DISABLED_BANNER_IDS: Array<string | number> = [
-  'keystore-secret-backup' // "Enable extension password reset via email" banner
+  'keystore-secret-backup', // "Enable extension password reset via email" banner
+  '690dfe83a205554ad597efff' // "Devconnect will be wild for Ambire" marketing banner
 ]
 
 export const filterDisabledBanners = (banners: Banner[]): Banner[] => {

--- a/src/web/modules/PPv1/screens/dashboard/hooks/useBanners/useBanners.ts
+++ b/src/web/modules/PPv1/screens/dashboard/hooks/useBanners/useBanners.ts
@@ -75,5 +75,5 @@ export default function useBanners(): [BannerInterface[], BannerInterface[]] {
     firstCashbackBanner
   ])
 
-  return [controllerBanners, marketingBanners]
+  return [controllerBanners, filterDisabledBanners(marketingBanners)]
 }

--- a/src/web/modules/PPv1/tokenDetails/hooks/useBanners/useBanners.ts
+++ b/src/web/modules/PPv1/tokenDetails/hooks/useBanners/useBanners.ts
@@ -75,5 +75,5 @@ export default function useBanners(): [BannerInterface[], BannerInterface[]] {
     firstCashbackBanner
   ])
 
-  return [controllerBanners, marketingBanners]
+  return [controllerBanners, filterDisabledBanners(marketingBanners)]
 }


### PR DESCRIPTION
This PR disable some banners from the dashboard:

- "Devconnect will be wild for Ambire"
- "Enable extension password reset via email"