### PR TITLE
fix: check for non-nullish cache before returning it

### DIFF
--- a/src/web/contexts/railgunControllerStateContext/railgunControllerStateContext.tsx
+++ b/src/web/contexts/railgunControllerStateContext/railgunControllerStateContext.tsx
@@ -454,7 +454,7 @@ const RailgunControllerStateProvider: React.FC<any> = ({ children }) => {
     async (zkAddress: string, chainId: number): Promise<RailgunAccountCache | null> => {
       const s = latestBgStateRef.current
       const last = s.lastFetchedRailgunAccountCache
-      if (last && last.zkAddress === zkAddress && last.chainId === chainId) {
+      if (last && last.zkAddress === zkAddress && last.chainId === chainId && last.cache !== null) {
         return last.cache as RailgunAccountCache | null
       }
 


### PR DESCRIPTION
There seems to be a bug in handling account cache in storage. We set it to null here, so subsequent calls at runtime seem to encounter nullish cache:

https://github.com/ethereum/kohaku-commons/blob/350c35e1f7207d58303d28595a0fd9556dda7f77/src/controllers/railgun/railgun.ts#L280-L285

So I propose we check it before returning.